### PR TITLE
add: Add pending status and error code checks for responses

### DIFF
--- a/src/Message/CreatePaymentResponse.php
+++ b/src/Message/CreatePaymentResponse.php
@@ -16,7 +16,7 @@ class CreatePaymentResponse extends Response
 
     public function isPending(): bool
     {
-        return in_array($this->getStatusCategory(), [
+        return parent::isPending() || in_array($this->getStatusCategory(), [
             self::STATUS_CATEGORY_CREATED,
             self::STATUS_CATEGORY_PENDING_PAYMENT,
             self::STATUS_CATEGORY_PENDING_CONNECT_OR_3RD_PARTY,

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -27,6 +27,9 @@ class Response extends AbstractResponse
     const STATUS_REFUND_REQUESTED = 'REFUND_REQUESTED';
     const STATUS_REFUNDED = 'REFUNDED';
 
+    const PENDING_STATUS_CODES = [46, 50, 51, 52, 55];
+    const PENDING_ERROR_CODES = [20001111, 20001006, 20001101];
+
     public function __construct(RequestInterface $request, $data, protected int $code)
     {
         parent::__construct($request, $data);
@@ -63,6 +66,17 @@ class Response extends AbstractResponse
         }
 
         return '';
+    }
+
+    public function isPending(): bool
+    {
+        return in_array($this->getStatusCode(), self::PENDING_STATUS_CODES)
+            && in_array($this->getCode(), self::PENDING_ERROR_CODES);
+    }
+
+    public function getStatusCode()
+    {
+        return $this->data['paymentResult']['payment']['statusOutput']['statusCode'];
     }
 
     public function getCode()

--- a/tests/Unit/ResponseTest.php
+++ b/tests/Unit/ResponseTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Ampeco\OmnipayWlValina\Unit;
+
+use Ampeco\OmnipayWlValina\Message\CreatePaymentResponse;
+use Ampeco\OmnipayWlValina\Message\PurchaseRequest;
+use Ampeco\OmnipayWlValina\Message\Response;
+use Illuminate\Http\Request;
+use Omnipay\Common\Http\Client;
+use PHPUnit\Framework\TestCase;
+
+class ResponseTest extends TestCase
+{
+    /**
+     * @dataProvider responseClasses
+     * @test
+     */
+    public function it_tests_response_is_pending_when_both_conditions_are_matched($responseClass)
+    {
+        $response = new $responseClass(request: (new PurchaseRequest(new Client(), new Request)), data: [
+            'paymentResult' => [
+                'payment' => [
+                    'status' => 'PENDING_CAPTURE',
+                    'statusOutput' => [
+                        'errors' => [
+                            [
+                                'errorCode' => 20001111,
+                            ],
+                        ],
+                        'isCancellable' => true,
+                        'statusCategory' => 'PENDING_MERCHANT',
+                        'statusCode' => 46,
+                        'isAuthorized' => true,
+                        'isRefundable' => false,
+                    ],
+                ],
+            ],
+
+        ], code: 200);
+
+        $this->assertTrue($response->isPending());
+    }
+
+    /**
+     * @dataProvider responseClasses
+     * @test
+     */
+    public function it_tests_response_not_pending_when_error_code_matches_but_status_code_does_not($responseClass)
+    {
+        $response = new $responseClass(request: (new PurchaseRequest(new Client(), new Request)), data: [
+            'paymentResult' => [
+                'payment' => [
+                    'status' => 'PENDING_CAPTURE',
+                    'statusOutput' => [
+                        'errors' => [
+                            [
+                                'errorCode' => 20001111,
+                            ],
+                        ],
+                        'isCancellable' => true,
+                        'statusCategory' => 'PENDING_MERCHANT',
+                        'statusCode' => 2,
+                        'isAuthorized' => true,
+                        'isRefundable' => false,
+                    ],
+                ],
+            ],
+
+        ], code: 200);
+
+        $this->assertNotTrue($response->isPending());
+    }
+
+    /**
+     * @dataProvider responseClasses
+     * @test
+     */
+    public function it_tests_response_not_pending_when_status_code_matches_but_error_code_does_not($responseClass)
+    {
+        $response = new $responseClass(request: (new PurchaseRequest(new Client(), new Request)), data: [
+            'paymentResult' => [
+                'payment' => [
+                    'status' => 'PENDING_CAPTURE',
+                    'statusOutput' => [
+                        'errors' => [
+                            [
+                                'errorCode' => 11111111,
+                            ],
+                        ],
+                        'isCancellable' => true,
+                        'statusCategory' => 'PENDING_MERCHANT',
+                        'statusCode' => 46,
+                        'isAuthorized' => true,
+                        'isRefundable' => false,
+                    ],
+                ],
+            ],
+
+        ], code: 200);
+
+        $this->assertNotTrue($response->isPending());
+    }
+
+    public static function responseClasses(): array
+    {
+        return [
+            'response' => [Response::class],
+            'payment_response' => [CreatePaymentResponse::class],
+        ];
+    }
+}


### PR DESCRIPTION
Introduce constants for pending status and error codes to `Response` and implement an `isPending` method. Update `CreatePaymentResponse` to utilize the new `isPending` logic from the parent class alongside existing status category checks. This improves clarity and consistency in handling pending states.